### PR TITLE
errorを出力させて設定ミスを修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-up:
+db.up:
 	docker-compose up -d
 
-down:
+db.down:
 	docker-compose down
 
-exec:
+db.exec:
 	docker-compose exec db bash
 
 setup:


### PR DESCRIPTION
fix: #6 

しかしlogは相変わらず期待するものは流れない・

```
❯ go run ./consumer
START_REPLICATION SLOT replication_slot LOGICAL 0/0 
server: confirmed standby
server: confirmed standby
server: confirmed standby
server: confirmed standby
```